### PR TITLE
[feat]: [CI-12621]: Update buildx version for dlc savings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gar
 go 1.19
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.0
+	github.com/drone-plugins/drone-buildx v1.1.7
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/oauth2 v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.0.2 h1:zlqCAko0frvNO9kXUPnsoyc0BxDoR93s5ieaTDItdDw=
-github.com/drone-plugins/drone-buildx v1.0.2/go.mod h1:z4BaR8J5oF/yly5VPW0PU61XOmrqsZvb5kdarmmSmho=
-github.com/drone-plugins/drone-buildx v1.0.3 h1:xaKX5yA0oUKM35EFnlAmHcrOKg9cmSJPKkdj3AMKyNo=
-github.com/drone-plugins/drone-buildx v1.0.3/go.mod h1:z4BaR8J5oF/yly5VPW0PU61XOmrqsZvb5kdarmmSmho=
-github.com/drone-plugins/drone-buildx v1.1.0 h1:sajkujeaykvWmAfvN89OOYFEWU2ho/s28QLY44ajrWs=
-github.com/drone-plugins/drone-buildx v1.1.0/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
+github.com/drone-plugins/drone-buildx v1.1.7 h1:v++Lb1xJ5pAyN/Mo+NZFtuDLvyWRdGM+LgzuSsArHqU=
+github.com/drone-plugins/drone-buildx v1.1.7/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Cache metrics being successfully written, parsed and uploaded to ti-service

<img width="1728" alt="Screenshot 2024-05-31 at 2 59 13 PM" src="https://github.com/drone-plugins/drone-buildx-gar/assets/114451080/dd98a550-ce3a-4646-9dff-94f02e3103ee">
<img width="1728" alt="Screenshot 2024-05-31 at 2 59 19 PM" src="https://github.com/drone-plugins/drone-buildx-gar/assets/114451080/e98cf372-3f1e-46de-b304-8308fbe9e4a2">
<img width="1728" alt="Screenshot 2024-05-31 at 2 59 36 PM" src="https://github.com/drone-plugins/drone-buildx-gar/assets/114451080/ddd99cd1-9a7c-498b-a3c0-9dd51b3433ae">
