### PR TITLE
Upgrade base buildx plugin version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gar
 go 1.21
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.13
+	github.com/drone-plugins/drone-buildx v1.1.14
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/oauth2 v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.1.13 h1:C9TalQBFOEWWIgiTTTtHFcNIgoyGuYF8rd26UXK1AX0=
-github.com/drone-plugins/drone-buildx v1.1.13/go.mod h1:loDc/WeyLXbxABq23i8avR9V4u8t+vVDw7l41Tv2/nk=
+github.com/drone-plugins/drone-buildx v1.1.14 h1:t+z65snQQmmgd9w3QmHXXm0k/BrVQKq/fR31aHLLABc=
+github.com/drone-plugins/drone-buildx v1.1.14/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
This upgrade includes changes in base buildx version:

Changed the login to docker login command instead of using the Config struct for OIDC changes.
Made the decision to use login instead of writing file directly.
Why the change was made - The login function integrates with various credential helpers, it also handles different registry specific logic in a better way, as opposed to config write where different registries need to be addressed differently.
It handles any changes in the authentication process across different Docker versions.

What is tested- GCR/ECR/ACR build and push steps with DLC
https://docs.google.com/document/d/1dzLf7PR43NiTjdScxu5gUgWO8O3QTonaDupSDIivFuU/edit

https://docs.google.com/document/d/1aH1t4Su-2YX8Hj-kj2OBxOUs7H3T0Lup2f1nxhlbGj4/edit