### PR TITLE
feat: [CI-17135]: Update dependent buildx to v1.2.3 that includes push-only support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.0
 
 require (
-	github.com/drone-plugins/drone-buildx v1.2.3-debug
+	github.com/drone-plugins/drone-buildx v1.2.3
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/oauth2 v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.0
 
 require (
-	github.com/drone-plugins/drone-buildx v1.2.1
+	github.com/drone-plugins/drone-buildx v1.2.3-debug
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/oauth2 v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.2.1 h1:a7eN1oy4u8PqeFPiG2gDhRfKWdw8WvkwRYLD/tvnGPw=
-github.com/drone-plugins/drone-buildx v1.2.1/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
+github.com/drone-plugins/drone-buildx v1.2.3-debug h1:j4kHsIdL49B67XrXW7+vmVOvLB1peL63id2n11nIDR8=
+github.com/drone-plugins/drone-buildx v1.2.3-debug/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.2.3-debug h1:j4kHsIdL49B67XrXW7+vmVOvLB1peL63id2n11nIDR8=
-github.com/drone-plugins/drone-buildx v1.2.3-debug/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
+github.com/drone-plugins/drone-buildx v1.2.3 h1:DLmWPzQvwa7DBhczjzrfYieQLgvAszHHS0DkkeiJJns=
+github.com/drone-plugins/drone-buildx v1.2.3/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
https://github.com/drone-plugins/drone-buildx/pull/62

Test execution [LINK](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/buildxgarwithtar/deployments/mJD_oZmSRtG0OpG7fBq6xg/pipeline?storeType=INLINE&step=rg7LcOBRSvKFFcRImheDWA&stage=3fdwhcFKT9qYa5uT9cTARA&childStage=&stageExecId=)