### PR TITLE
feat: [CI-23661]: windows 2025 support

### DIFF
--- a/docker/gar/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/gar/Dockerfile.windows.amd64.ltsc2025
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2025-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone GAR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-gar.exe C:/bin/buildx-gar.exe
+ENTRYPOINT [ "C:\\bin\\buildx-gar.exe" ]

--- a/docker/gar/manifest.tmpl
+++ b/docker/gar/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/buildx-gar:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC) for the `buildx-gar` Docker image. The main changes include introducing a new Dockerfile for the `windows-ltsc2025-amd64` platform and updating the manifest to include this new variant.

**Windows Server 2025 (LTSC) support:**

* Added `docker/gar/Dockerfile.windows.amd64.ltsc2025` to build the `buildx-gar` image for Windows Server 2025 (LTSC) on amd64.
* Updated `docker/gar/manifest.tmpl` to reference the new Windows Server 2025 (LTSC) image in the multi-platform manifest.