### PR TITLE
feat: [CI-23744]: bump drone-buildx to v1.3.23 for proxy and CA support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gar
 go 1.26
 
 require (
-	github.com/drone-plugins/drone-buildx v1.3.20
+	github.com/drone-plugins/drone-buildx v1.3.23
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.4
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.20 h1:Oe9Jn/fyBS7YKRlvSnEGUS5ouN6M+Yhwjf75Acap2sw=
-github.com/drone-plugins/drone-buildx v1.3.20/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
+github.com/drone-plugins/drone-buildx v1.3.23 h1:ntXvbatGFU8oIuQU2n6kARn93EfrS2jVKs9MDBvYaDc=
+github.com/drone-plugins/drone-buildx v1.3.23/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
## Problem
BuildKit containers running behind the Harness egress proxy cannot reach external registries and encounter x509 certificate errors when attempting TLS connections.

## Root Cause
drone-buildx-gar depends on drone-buildx v1.3.20, which does not forward standard proxy environment variables (http_proxy, https_proxy, no_proxy) or HARNESS_CA_PATH to BuildKit containers. BuildKit runs in an isolated docker-container driver and does not inherit the host's environment or certificate trust store.

## Solution
Bumped drone-buildx dependency from v1.3.20 to v1.3.23 to inherit the proxy and CA forwarding fixes from https://github.com/drone-plugins/drone-buildx/pull/115

## Changes Made
- **go.mod**: Updated drone-buildx dependency to v1.3.23
- **go.sum**: Updated checksums

The v1.3.23 release includes:
✅ Standard proxy var forwarding (http_proxy, https_proxy, no_proxy)
✅ HARNESS_CA_PATH certificate forwarding to BuildKit containers via driver-opt env.* mechanism
✅ Precedence handling: standard vars → uppercase vars → HARNESS_* vars

## Testing
- ✅ Build passes: `go build ./...`
- ✅ No test regressions (repo has no test files)
- ✅ Pattern validated against identical fixes in drone-buildx-acr, drone-buildx-ecr, drone-buildx-gcr

## Related Issues/Logs
- JIRA: [CI-23744](https://harness.atlassian.net/browse/CI-23744)
- Upstream fix: https://github.com/drone-plugins/drone-buildx/pull/115
- Related PRs: 
  - https://github.com/drone-plugins/drone-buildx-acr/pull/65
  - https://github.com/drone-plugins/drone-buildx-ecr/pull/67

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-23744]: https://harness.atlassian.net/browse/CI-23744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ