### PR TITLE
feat: [CI-23756]: windows 2025 rf stage

### DIFF
--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -114,7 +114,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
               infrastructure:
                 type: VM
                 spec:
@@ -202,7 +202,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -309,7 +309,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -416,7 +416,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"   
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -539,7 +539,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -662,7 +662,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"   
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -755,7 +755,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -847,7 +847,7 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: |
-                          <+codebase.build.type> == "branch"      
+                          <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String
@@ -916,6 +916,112 @@ pipeline:
                       when:
                         stageStatus: Success
                         condition: <+codebase.build.type> == "tag"
+                  - step:
+                      type: BuildAndPushDockerRegistry
+                      name: Build and Push on Branch
+                      identifier: BuildAndPushDockerRegistry_ltsc2025
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        repo: plugins/buildx-gar
+                        tags:
+                          - windows-ltsc2025-amd64
+                        caching: false
+                        dockerfile: docker/gar/Dockerfile.windows.amd64.ltsc2025
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "branch"
+            variables:
+              - name: DRONE_REPO_OWNER
+                type: String
+                description: ""
+                required: false
+                value: drone-plugins
+        - stage:
+            name: win-ltsc2025-amd64-rf
+            identifier: winltsc2025amd64rf
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              caching:
+                enabled: false
+                paths: []
+              buildIntelligence:
+                enabled: false
+              infrastructure:
+                type: VM
+                spec:
+                  type: Pool
+                  spec:
+                    poolName: windows-2025
+                    os: Windows
+              execution:
+                steps:
+                  - step:
+                      type: GitClone
+                      name: Clone RF Dockerfiles
+                      identifier: Clone_RF_Dockerfiles
+                      spec:
+                        connectorRef: RapidFortPlugins
+                        cloneDirectory: rf-plugins
+                        build:
+                          type: branch
+                          spec:
+                            branch: main
+                  - step:
+                      type: Run
+                      name: Build binaries
+                      identifier: Build
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        image: golang:1.26
+                        shell: Sh
+                        command: |-
+                          # force go modules
+                          export GOPATH=""
+
+                          # disable cgo
+                          export CGO_ENABLED=0
+
+                          set -e
+                          set -x
+
+                          # windows
+                          GOOS=windows
+
+                          go build -buildvcs=false -o release/windows/amd64/buildx-gar.exe ./cmd/drone-buildx-gar
+                  - step:
+                      type: Plugin
+                      name: RF Build and Push on Tag
+                      identifier: RF_Build_and_Push_on_Tag
+                      spec:
+                        connectorRef: Plugins_Docker_Hub_Connector
+                        image: plugins/docker:21.3.0
+                        settings:
+                          username: <+secrets.getValue("harnesssecureusername")>
+                          password: <+secrets.getValue("dockerHarnessSecurePwd")>
+                          repo: harnesssecure/buildx-gar
+                          dockerfile: rf-plugins/drone-buildx-gar/Dockerfile.windows.amd64.ltsc2025
+                          auto_tag: "true"
+                          auto_tag_suffix: windows-ltsc2025-amd64
+                          purge: "false"
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "tag"
+                  - step:
+                      type: BuildAndPushDockerRegistry
+                      name: RF Build and Push on Branch
+                      identifier: rf_build_push_branch
+                      spec:
+                        connectorRef: harnesssecure
+                        repo: harnesssecure/buildx-gar
+                        tags:
+                          - windows-ltsc2025-amd64
+                        caching: false
+                        dockerfile: rf-plugins/drone-buildx-gar/Dockerfile.windows.amd64.ltsc2025
+                      when:
+                        stageStatus: Success
+                        condition: <+codebase.build.type> == "branch"
             variables:
               - name: DRONE_REPO_OWNER
                 type: String


### PR DESCRIPTION
Add Windows Server 2025 RapidFort pipeline stages.

Changes:
- Add "Build and Push on Branch" step to existing `win-ltsc2025` stage
- Add new `win-ltsc2025-amd64-rf` stage using `windows-2025` pool with RF Dockerfiles and `plugins/docker:21.3.0`